### PR TITLE
fix context timout

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A tool for checking the accessibility of your data by IPFS peers
 
 ### Deploy
 
-There are web assets in `web` that interacts with the Go HTTP server that can be deployed however you deploy web assets.
+There are web assets in `web` that interact with the Go HTTP server that can be deployed however you deploy web assets.
 Maybe just deploy it on IPFS and reference it with DNSLink.
 
 For anything other than local testing you're going to want to have a proxy to give you HTTPS support on the Go server.
@@ -55,6 +55,23 @@ go build
 npx -y serve -l 3000 web
 # Then open http://localhost:3000?backendURL=http://localhost:3333
 ```
+
+## Metrics
+
+The ipfs-check server is instrumented and exposes two Prometheus metrics endpoints:
+
+- `/metrics/libp2p` exposes [go-libp2p metrics](https://blog.libp2p.io/2023-08-15-metrics-in-go-libp2p/).
+- `/metrics/http` exposes http metrics for the check endpoint.
+
+### Securing the metrics endpoints
+
+To add HTTP basic auth to the two metrics endpoints, you can use the `--metrics-auth-username` and `--metrics-auth-password` flags:
+
+```
+./ipfs-check --metrics-auth-username=user --metrics-auth-password=pass
+```
+
+Alternatively, you can use the `IPFS_CHECK_METRICS_AUTH_USER` and `IPFS_CHECK_METRICS_AUTH_PASS` env vars.
 
 ## License
 

--- a/daemon.go
+++ b/daemon.go
@@ -175,17 +175,17 @@ func (d *daemon) runCheck(query url.Values) (*output, error) {
 		out.DataAvailableOverBitswap.Error = "could not connect to peer"
 	} else {
 		// If so is the data available over Bitswap?
-		out.DataAvailableOverBitswap = checkBitswapCID(ctx, c, ma)
+		out.DataAvailableOverBitswap = checkBitswapCID(ctx, testHost, c, ma)
 	}
 
 	return out, nil
 }
 
-func checkBitswapCID(ctx context.Context, c cid.Cid, ma multiaddr.Multiaddr) BitswapCheckOutput {
+func checkBitswapCID(ctx context.Context, host host.Host, c cid.Cid, ma multiaddr.Multiaddr) BitswapCheckOutput {
 	out := BitswapCheckOutput{}
 	start := time.Now()
 
-	bsOut, err := vole.CheckBitswapCID(ctx, c, ma, false)
+	bsOut, err := vole.CheckBitswapCID(ctx, host, c, ma, false)
 	if err != nil {
 		out.Error = err.Error()
 	} else {

--- a/daemon.go
+++ b/daemon.go
@@ -123,6 +123,9 @@ func (d *daemon) runCheck(query url.Values) (*output, error) {
 		return nil, err
 	}
 
+	// User has only passed a PeerID without any maddrs
+	onlyPeerID := len(ai.Addrs) == 0
+
 	c, err := cid.Decode(cidStr)
 	if err != nil {
 		return nil, err
@@ -138,9 +141,10 @@ func (d *daemon) runCheck(query url.Values) (*output, error) {
 	addrMap, peerAddrDHTErr := peerAddrsInDHT(ctx, d.dht, d.dhtMessenger, ai.ID)
 	out.PeerFoundInDHT = addrMap
 
-	// If peerID given, but no addresses check the DHT
-	if len(ai.Addrs) == 0 {
+	// If peerID given,but no addresses check the DHT
+	if onlyPeerID {
 		if peerAddrDHTErr != nil {
+			// PeerID is not resolvable via the DHT
 			connectionFailed = true
 			out.ConnectionError = peerAddrDHTErr.Error()
 		}

--- a/daemon.go
+++ b/daemon.go
@@ -166,7 +166,7 @@ func (d *daemon) runCheck(query url.Values) (*output, error) {
 		connErr := testHost.Connect(dialCtx, *ai)
 		dialCancel()
 		if connErr != nil {
-			out.ConnectionError = connErr.Error()
+			out.ConnectionError = fmt.Sprintf("error dialing to peer: %s", connErr.Error())
 			connectionFailed = true
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/gavv/httpexpect/v2 v2.16.0
-	github.com/ipfs-shipyard/vole v0.0.0-20240704031213-bd92d8918fb2
+	github.com/ipfs-shipyard/vole v0.0.0-20240801195547-d7b80a461193
 	github.com/ipfs/boxo v0.21.0
 	github.com/ipfs/go-block-format v0.2.0
 	github.com/ipfs/go-cid v0.4.1
@@ -17,6 +17,7 @@ require (
 	github.com/libp2p/go-msgio v0.3.0
 	github.com/multiformats/go-multiaddr v0.13.0
 	github.com/multiformats/go-multihash v0.2.3
+	github.com/prometheus/client_golang v1.19.1
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.27.3
 )
@@ -132,7 +133,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polydawn/refmt v0.89.0 // indirect
-	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFck
 github.com/imkira/go-interpol v1.1.0 h1:KIiKr0VSG2CUW1hl1jpiyuzuJeKUUpC8iM1AIE7N1Vk=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/ipfs-shipyard/vole v0.0.0-20240704031213-bd92d8918fb2 h1:ZoJvCQJpdrim33d21Rl0HCPA9oVT2ncpN/lZ9olz68o=
-github.com/ipfs-shipyard/vole v0.0.0-20240704031213-bd92d8918fb2/go.mod h1:ibnGHr4b6P1OYWIR2HLKT1ONUbmd1ZGe9gzRWb/Kcto=
+github.com/ipfs-shipyard/vole v0.0.0-20240801195547-d7b80a461193 h1:5HPfcUkFXM5KvIKzViKNs00NfLP22IW/KBuV7uFoQl0=
+github.com/ipfs-shipyard/vole v0.0.0-20240801195547-d7b80a461193/go.mod h1:ibnGHr4b6P1OYWIR2HLKT1ONUbmd1ZGe9gzRWb/Kcto=
 github.com/ipfs/bbloom v0.0.4 h1:Gi+8EGJ2y5qiD5FbsbpX/TMNcJw8gSqr7eyjHa4Fhvs=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
 github.com/ipfs/boxo v0.21.0 h1:XpGXb+TQQ0IUdYaeAxGzWjSs6ow/Lce148A/2IbRDVE=

--- a/integration_test.go
+++ b/integration_test.go
@@ -70,7 +70,7 @@ func TestBasicIntegration(t *testing.T) {
 					libp2p.EnableHolePunching())
 			},
 		}
-		_ = startServer(ctx, d, ":1234")
+		_ = startServer(ctx, d, ":1234", "", "")
 	}()
 
 	h, err := libp2p.New()

--- a/test/tools.go
+++ b/test/tools.go
@@ -43,7 +43,7 @@ func Query(
 
 	e := httpexpect.Default(t, url)
 
-	return e.POST("/").
+	return e.POST("/check").
 		WithQuery("cid", cid).
 		WithQuery("multiaddr", multiaddr).
 		Expect().

--- a/web/index.html
+++ b/web/index.html
@@ -163,8 +163,8 @@
     function formatOutput (formData, respObj) {
         const ma = formData.get('multiaddr')
         const peerIDStartIndex = ma.lastIndexOf("/p2p/")
-        const peerID = ma.substr(peerIDStartIndex + 5, ma.length)
-        const addrPart = ma.substr(0, peerIDStartIndex)
+        const peerID = ma.slice(peerIDStartIndex + 5);
+        const addrPart = ma.slice(0, peerIDStartIndex);
         let outText = ""
 
         if (respObj.ConnectionError !== "") {
@@ -174,6 +174,7 @@
         }
 
         if (ma.indexOf("/p2p/") === 0 && ma.lastIndexOf("/") === 4) {
+            // only peer id passed with /p2p/PeerID
             if (Object.keys(respObj.PeerFoundInDHT).length === 0) {
                 outText += "❌ Could not find any multiaddrs in the dht\n"
             } else {
@@ -183,6 +184,7 @@
                 }
             }
         } else {
+            // a proper maddr with an IP was passed
             let foundAddr = false
             for (const key in respObj.PeerFoundInDHT) {
                 if (key === addrPart) {

--- a/web/index.html
+++ b/web/index.html
@@ -176,7 +176,7 @@
         if (respObj.ConnectionError !== "") {
             outText += "❌ Could not connect to multiaddr: " + respObj.ConnectionError + "\n"
         } else {
-            outText += "✔ Successfully connected to multiaddr\n"
+            outText += "✅ Successfully connected to multiaddr\n"
         }
 
         if (ma.indexOf("/p2p/") === 0 && ma.lastIndexOf("/") === 4) {
@@ -184,7 +184,7 @@
             if (Object.keys(respObj.PeerFoundInDHT).length === 0) {
                 outText += "❌ Could not find any multiaddrs in the dht\n"
             } else {
-                outText += "✔ Found multiaddrs advertised in the DHT:\n"
+                outText += "✅ Found multiaddrs advertised in the DHT:\n"
                 for (const key in respObj.PeerFoundInDHT) {
                     outText += "\t" + key + "\n"
                 }
@@ -195,7 +195,7 @@
             for (const key in respObj.PeerFoundInDHT) {
                 if (key === addrPart) {
                     foundAddr = true
-                    outText += "✔ Found multiaddr with " + respObj.PeerFoundInDHT[key] + " dht peers\n"
+                    outText += "✅ Found multiaddr with " + respObj.PeerFoundInDHT[key] + " dht peers\n"
                     break
                 }
             }
@@ -208,7 +208,7 @@
         }
         
         if (respObj.CidInDHT === true) {
-            outText += "✔ Found multihash advertised in the dht\n"
+            outText += "✅ Found multihash advertised in the dht\n"
         } else {
             outText += "❌ Could not find the multihash in the dht\n"
         }
@@ -218,7 +218,7 @@
         } else if (respObj.DataAvailableOverBitswap.Responded !== true) {
             outText += "❌ The peer did not quickly respond if it had the CID\n"
         } else if (respObj.DataAvailableOverBitswap.Found === true) {
-            outText += "✔ The peer responded that it has the CID\n"
+            outText += "✅ The peer responded that it has the CID\n"
         } else {
             outText += "❌ The peer responded that it does not have the CID\n"
         }

--- a/web/index.html
+++ b/web/index.html
@@ -111,16 +111,22 @@
             const backendURL = getBackendUrl(formData)
             
             showInQuery(formData) // add `cid` and `multiaddr` to local url query to make it shareable
-            toggleSubmitButton()            
-            const res = await fetch(backendURL, { method: 'POST' })
             toggleSubmitButton()
-            if (res.ok) {
-                const respObj = await res.json()
-                const output = formatOutput(formData, respObj)
-                showOutput(output)
-            } else {
-                const resText = await res.text()
-                showOutput(`⚠️ backend returned an error: ${res.status} ${resText}`)
+            try {
+              const res = await fetch(backendURL, { method: 'POST' })
+
+              if (res.ok) {
+                  const respObj = await res.json()
+                  const output = formatOutput(formData, respObj)
+                  showOutput(output)
+              } else {
+                  const resText = await res.text()
+                  showOutput(`⚠️ backend returned an error: ${res.status} ${resText}`)
+              }
+            } catch (e) {
+              showOutput(`⚠️ backend error: ${e}`)
+            } finally {
+              toggleSubmitButton()
             }
         })
     })


### PR DESCRIPTION
### What's in this PR

- **chore: avoid substr in favour of modern js**
- **chore: make sure connection error is distinct**
- [fix: add try-catch to toggle submit on failure](https://github.com/ipfs-shipyard/ipfs-check/pull/37/commits/20de1dc3c35c57a76dadb0f4c7284d722aa6f23a)
- Reuse temp libp2p host in checks to avoid creation of two temporary libp2p hosts per bitswap check
- Add instrumentation
- Change the check http path to `/check` to avoid the root `/` handler catching all request (including `/favicon`)


Depends on https://github.com/ipfs-shipyard/vole/pull/43 