### PR TITLE
fix: refine errors for private maddr dial failures

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"time"
 
@@ -310,7 +311,7 @@ func (d *daemon) runCidCheck(ctx context.Context, cidKey cid.Cid, ipniURL string
 			_, connErr := testHost.NewStream(dialCtx, provider.ID, "/ipfs/bitswap/1.2.0", "/ipfs/bitswap/1.1.0", "/ipfs/bitswap/1.0.0", "/ipfs/bitswap")
 
 			if connErr != nil {
-				provOutput.ConnectionError = connErr.Error()
+				provOutput.ConnectionError = formatConnectionError(connErr, provider.Addrs)
 			} else {
 				// since we pass a libp2p host that's already connected to the peer the actual connection maddr we pass in doesn't matter
 				p2pAddr, _ := multiaddr.NewMultiaddr("/p2p/" + provider.ID.String())
@@ -441,7 +442,7 @@ func (d *daemon) runPeerCheck(ctx context.Context, ma multiaddr.Multiaddr, ai pe
 		_, connErr := testHost.NewStream(dialCtx, libp2pInfo.ID, "/ipfs/bitswap/1.2.0", "/ipfs/bitswap/1.1.0", "/ipfs/bitswap/1.0.0", "/ipfs/bitswap")
 		dialCancel()
 		if connErr != nil {
-			out.ConnectionError = connErr.Error()
+			out.ConnectionError = formatConnectionError(connErr, libp2pInfo.Addrs)
 			return out, nil
 		}
 	}
@@ -754,4 +755,36 @@ func execOnMany(ctx context.Context, waitFrac float64, timeoutPerOp time.Duratio
 		}
 	}
 	return numSuccess
+}
+
+// formatConnectionError provides a more user-friendly error message for connection failures,
+// particularly when the connection gater blocks private addresses
+func formatConnectionError(err error, addrs []multiaddr.Multiaddr) string {
+	errStr := err.Error()
+
+	// Check if this looks like a gater blocking private addresses error
+	if strings.Contains(errStr, "gater disallows connection to peer") {
+		var privateCount, publicCount int
+
+		// Count private vs public addresses
+		for _, addr := range addrs {
+			if manet.IsPublicAddr(addr) {
+				publicCount++
+			} else {
+				privateCount++
+			}
+		}
+
+		// If we have private addresses being blocked, provide a cleaner message
+		if privateCount > 0 {
+			if publicCount == 0 {
+				return fmt.Sprintf("failed to dial: all %d addresses are private/local and cannot be reached from public internet", privateCount)
+			} else {
+				return fmt.Sprintf("failed to dial: no good addresses (%d private addresses filtered out)", privateCount)
+			}
+		}
+	}
+
+	// For other errors, return the original error message
+	return errStr
 }

--- a/format_error_test.go
+++ b/format_error_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatConnectionError(t *testing.T) {
+	t.Run("gater disallows connection - all private addresses", func(t *testing.T) {
+		err := errors.New("failed to dial: no good addresses\n* [/ip4/10.157.217.171/tcp/4001] gater disallows connection to peer\n* [/ip4/127.0.0.1/tcp/4001] gater disallows connection to peer")
+
+		addrs := []multiaddr.Multiaddr{}
+		privAddr1, _ := multiaddr.NewMultiaddr("/ip4/10.157.217.171/tcp/4001")
+		privAddr2, _ := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/4001")
+		addrs = append(addrs, privAddr1, privAddr2)
+
+		result := formatConnectionError(err, addrs)
+		expected := "failed to dial: all 2 addresses are private/local and cannot be reached from public internet"
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("gater disallows connection - mixed private and public addresses", func(t *testing.T) {
+		err := errors.New("failed to dial: no good addresses\n* [/ip4/10.157.217.171/tcp/4001] gater disallows connection to peer\n* [/ip4/8.8.8.8/tcp/4001] some other error")
+
+		addrs := []multiaddr.Multiaddr{}
+		privAddr, _ := multiaddr.NewMultiaddr("/ip4/10.157.217.171/tcp/4001")
+		pubAddr, _ := multiaddr.NewMultiaddr("/ip4/8.8.8.8/tcp/4001")
+		addrs = append(addrs, privAddr, pubAddr)
+
+		result := formatConnectionError(err, addrs)
+		expected := "failed to dial: no good addresses (1 private addresses filtered out)"
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("gater disallows connection - no private addresses detected", func(t *testing.T) {
+		err := errors.New("failed to dial: no good addresses\n* [/ip4/8.8.8.8/tcp/4001] gater disallows connection to peer")
+
+		addrs := []multiaddr.Multiaddr{}
+		pubAddr, _ := multiaddr.NewMultiaddr("/ip4/8.8.8.8/tcp/4001")
+		addrs = append(addrs, pubAddr)
+
+		result := formatConnectionError(err, addrs)
+		// Should return original error since no private addresses were detected
+		require.Equal(t, err.Error(), result)
+	})
+
+	t.Run("non-gater error", func(t *testing.T) {
+		err := errors.New("some other connection error")
+
+		addrs := []multiaddr.Multiaddr{}
+		privAddr, _ := multiaddr.NewMultiaddr("/ip4/10.157.217.171/tcp/4001")
+		addrs = append(addrs, privAddr)
+
+		result := formatConnectionError(err, addrs)
+		// Should return original error for non-gater errors
+		require.Equal(t, err.Error(), result)
+	})
+
+	t.Run("gater disallows connection - with IPv6 private addresses", func(t *testing.T) {
+		err := errors.New("failed to dial: no good addresses\n* [/ip6/::1/tcp/4001] gater disallows connection to peer\n* [/ip6/fc00:bbbb:bbbb:bb01:d:0:1d:d9ab/tcp/4001] gater disallows connection to peer")
+
+		addrs := []multiaddr.Multiaddr{}
+		privAddr1, _ := multiaddr.NewMultiaddr("/ip6/::1/tcp/4001")
+		privAddr2, _ := multiaddr.NewMultiaddr("/ip6/fc00:bbbb:bbbb:bb01:d:0:1d:d9ab/tcp/4001")
+		addrs = append(addrs, privAddr1, privAddr2)
+
+		result := formatConnectionError(err, addrs)
+		expected := "failed to dial: all 2 addresses are private/local and cannot be reached from public internet"
+		require.Equal(t, expected, result)
+	})
+}


### PR DESCRIPTION
When connection gater blocks private addresses, provide clearer error messages
instead of showing detailed "gater disallows connection to peer" errors.

- Add formatConnectionError function to detect and summarize private address failures
- Show "all X addresses are private/local" when only private addresses are found
- Show "no good addresses (X private addresses filtered out)" when mixed
- Preserve original error messages for other connection failures
- Add tests for error formatting scenarios

Fixes #96
