### PR TITLE
feat: non-blocking accelerated DHT initialization

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -13,15 +13,11 @@ import (
 	"github.com/ipfs/boxo/bitswap/message/pb"
 	"github.com/ipfs/boxo/bitswap/network"
 	"github.com/ipfs/boxo/bitswap/network/httpnet"
-	"github.com/ipfs/boxo/ipns"
 	"github.com/ipfs/boxo/routing/http/client"
 	"github.com/ipfs/boxo/routing/http/contentrouter"
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p"
-	dht "github.com/libp2p/go-libp2p-kad-dht"
-	"github.com/libp2p/go-libp2p-kad-dht/fullrt"
 	dhtpb "github.com/libp2p/go-libp2p-kad-dht/pb"
-	record "github.com/libp2p/go-libp2p-record"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
@@ -83,23 +79,8 @@ func newDaemon(ctx context.Context, acceleratedDHT bool) (*daemon, error) {
 		return nil, err
 	}
 
-	var d kademlia
-	if acceleratedDHT {
-		d, err = fullrt.NewFullRT(h, "/ipfs",
-			fullrt.DHTOption(
-				dht.BucketSize(20),
-				dht.Validator(record.NamespacedValidator{
-					"pk":   record.PublicKeyValidator{},
-					"ipns": ipns.Validator{},
-				}),
-				dht.BootstrapPeers(dht.GetDefaultBootstrapPeerAddrInfos()...),
-				dht.Mode(dht.ModeClient),
-			))
-
-	} else {
-		d, err = dht.New(ctx, h, dht.Mode(dht.ModeClient), dht.BootstrapPeers(dht.GetDefaultBootstrapPeerAddrInfos()...))
-	}
-
+	// Setup DHT (standard or bundled with accelerated)
+	d, err := setupDHT(ctx, h, acceleratedDHT)
 	if err != nil {
 		return nil, err
 	}
@@ -123,19 +104,6 @@ func newDaemon(ctx context.Context, acceleratedDHT bool) (*daemon, error) {
 				libp2p.UserAgent(userAgent),
 			)
 		}}, nil
-}
-
-func (d *daemon) mustStart() {
-	// Wait for the DHT to be ready
-	if frt, ok := d.dht.(*fullrt.FullRT); ok {
-		if !frt.Ready() {
-			log.Printf("Please wait, initializing accelerated-dht client.. (mapping Amino DHT takes 5 mins or more)")
-		}
-		for !frt.Ready() {
-			time.Sleep(time.Second * 1)
-		}
-		log.Printf("Accelerated DHT client is ready")
-	}
 }
 
 type cidCheckOutput *[]providerOutput

--- a/dht.go
+++ b/dht.go
@@ -2,13 +2,21 @@ package main
 
 import (
 	"context"
+	"log"
 	"time"
 
+	"github.com/ipfs/boxo/ipns"
+	"github.com/ipfs/go-cid"
+	dht "github.com/libp2p/go-libp2p-kad-dht"
+	"github.com/libp2p/go-libp2p-kad-dht/amino"
+	"github.com/libp2p/go-libp2p-kad-dht/fullrt"
 	dhtpb "github.com/libp2p/go-libp2p-kad-dht/pb"
+	record "github.com/libp2p/go-libp2p-record"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
+	"github.com/libp2p/go-libp2p/core/routing"
 	"github.com/libp2p/go-msgio/pbio"
 )
 
@@ -88,3 +96,117 @@ func (ms *dhtMsgSender) SendMessage(ctx context.Context, p peer.ID, pmes *dhtpb.
 }
 
 var _ dhtpb.MessageSender = (*dhtMsgSender)(nil)
+
+// bundledDHT combines standard and accelerated DHT clients
+// It starts with standard DHT for immediate functionality
+// and switches to accelerated DHT when it becomes ready
+type bundledDHT struct {
+	standard *dht.IpfsDHT
+	fullRT   *fullrt.FullRT
+}
+
+// getDHT returns the accelerated DHT if ready, otherwise standard DHT
+func (b *bundledDHT) getDHT() kademlia {
+	if b.fullRT != nil && b.fullRT.Ready() {
+		return b.fullRT
+	}
+	return b.standard
+}
+
+// Implement kademlia interface methods
+
+func (b *bundledDHT) Provide(ctx context.Context, c cid.Cid, brdcst bool) error {
+	return b.getDHT().Provide(ctx, c, brdcst)
+}
+
+func (b *bundledDHT) FindProvidersAsync(ctx context.Context, c cid.Cid, i int) <-chan peer.AddrInfo {
+	return b.getDHT().FindProvidersAsync(ctx, c, i)
+}
+
+func (b *bundledDHT) FindPeer(ctx context.Context, id peer.ID) (peer.AddrInfo, error) {
+	return b.getDHT().FindPeer(ctx, id)
+}
+
+func (b *bundledDHT) PutValue(ctx context.Context, k string, v []byte, option ...routing.Option) error {
+	return b.getDHT().PutValue(ctx, k, v, option...)
+}
+
+func (b *bundledDHT) GetValue(ctx context.Context, s string, option ...routing.Option) ([]byte, error) {
+	return b.getDHT().GetValue(ctx, s, option...)
+}
+
+func (b *bundledDHT) SearchValue(ctx context.Context, s string, option ...routing.Option) (<-chan []byte, error) {
+	return b.getDHT().SearchValue(ctx, s, option...)
+}
+
+func (b *bundledDHT) Bootstrap(ctx context.Context) error {
+	// Bootstrap the standard DHT
+	return b.standard.Bootstrap(ctx)
+}
+
+func (b *bundledDHT) GetClosestPeers(ctx context.Context, key string) ([]peer.ID, error) {
+	return b.getDHT().GetClosestPeers(ctx, key)
+}
+
+// Ensure bundledDHT implements kademlia interface
+var _ kademlia = (*bundledDHT)(nil)
+
+// setupDHT initializes the DHT client(s) based on configuration
+func setupDHT(ctx context.Context, h host.Host, acceleratedDHT bool) (kademlia, error) {
+	// Common validators for both DHT types
+	validators := record.NamespacedValidator{
+		"pk":   record.PublicKeyValidator{},
+		"ipns": ipns.Validator{},
+	}
+
+	// Always create standard DHT first (starts immediately)
+	standardDHT, err := dht.New(ctx, h,
+		dht.Mode(dht.ModeClient),
+		dht.Validator(validators),
+		dht.BootstrapPeers(dht.GetDefaultBootstrapPeerAddrInfos()...))
+	if err != nil {
+		return nil, err
+	}
+
+	// If not using accelerated DHT, return standard DHT only
+	if !acceleratedDHT {
+		return standardDHT, nil
+	}
+
+	// Create accelerated DHT in parallel (non-blocking)
+	fullRTDHT, err := fullrt.NewFullRT(h, dht.DefaultPrefix,
+		fullrt.DHTOption(
+			dht.BucketSize(amino.DefaultBucketSize),
+			dht.Validator(validators),
+			dht.BootstrapPeers(dht.GetDefaultBootstrapPeerAddrInfos()...),
+			dht.Mode(dht.ModeClient),
+		))
+	if err != nil {
+		return nil, err
+	}
+
+	// Create bundled DHT that will switch automatically
+	bundled := &bundledDHT{
+		standard: standardDHT,
+		fullRT:   fullRTDHT,
+	}
+
+	// Start monitoring for readiness in background
+	go monitorDHTReadiness(bundled)
+
+	return bundled, nil
+}
+
+// monitorDHTReadiness logs DHT status and notifies when accelerated DHT is ready
+func monitorDHTReadiness(b *bundledDHT) {
+	if !b.fullRT.Ready() {
+		log.Printf("Please wait, initializing accelerated-dht client, performance will improve soon (mapping Amino DHT takes 5 mins or more)")
+	}
+
+	// Check readiness every 10 seconds
+	for !b.fullRT.Ready() {
+		time.Sleep(10 * time.Second)
+	}
+
+	log.Printf("Accelerated DHT client is ready - DHT queries will now have improved performance")
+}

--- a/main.go
+++ b/main.go
@@ -86,8 +86,6 @@ func startServer(ctx context.Context, d *daemon, tcpListener, metricsUsername, m
 	log.Printf("Libp2p host peer id %s\n", d.h.ID())
 	log.Printf("Libp2p host listening on %v\n", d.h.Addrs())
 
-	d.mustStart()
-
 	log.Printf("Backend ready and listening on %v\n", l.Addr())
 
 	webAddr := getWebAddress(l)
@@ -211,9 +209,13 @@ func startServer(ctx context.Context, d *daemon, tcpListener, metricsUsername, m
 	// Serve frontend on /web
 	fileServer := http.FileServer(http.FS(webFS))
 	http.Handle("/web/", fileServer)
-	// Set up the root route to redirect to /web
+	// Set up the root route to redirect to /web/ with preserved query parameters
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		http.Redirect(w, r, "/web", http.StatusFound)
+		target := "/web/"
+		if r.URL.RawQuery != "" {
+			target = target + "?" + r.URL.RawQuery
+		}
+		http.Redirect(w, r, target, http.StatusFound)
 	})
 
 	done := make(chan error, 1)


### PR DESCRIPTION
This PR fixes "wait 5 min before accelerated dht works" problem.

- implement bundled DHT that starts with standard DHT immediately
- switch to accelerated DHT automatically when ready (~5 mins)
- preserve query parameters on root redirect to /web/

