### PR TITLE
feat: display peer agent version in diagnostics

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -53,9 +54,35 @@ const (
 
 	ipniSource = "IPNI"
 	dhtSource  = "Amino DHT"
+
+	// maximum length for agent version string
+	maxAgentVersionLen = 64
 )
 
 var defaultProtocolFilter = []string{"transport-bitswap", "unknown"}
+
+// Regex to match only ASCII printable characters (space through tilde)
+// This ensures we only keep safe, printable ASCII chars
+var asciiPrintable = regexp.MustCompile(`[^\x20-\x7E]`)
+
+// sanitizeAgentVersion removes non-printable characters and limits length.
+// The Go json.Marshal will handle proper escaping of quotes, backslashes, etc.
+func sanitizeAgentVersion(version string) string {
+	// Replace non-ASCII and non-printable characters with underscore
+	// This removes control characters, non-ASCII, etc.
+	ascii := asciiPrintable.ReplaceAllString(version, "_")
+
+	// Trim whitespace
+	ascii = strings.TrimSpace(ascii)
+
+	// Limit to maximum length (count runes for proper UTF-8 handling)
+	runes := []rune(ascii)
+	if len(runes) > maxAgentVersionLen {
+		ascii = string(runes[:maxAgentVersionLen])
+	}
+
+	return ascii
+}
 
 func newDaemon(ctx context.Context, acceleratedDHT bool) (*daemon, error) {
 	rm, err := NewResourceManager()
@@ -148,6 +175,7 @@ type providerOutput struct {
 	DataAvailableOverBitswap BitswapCheckOutput
 	DataAvailableOverHTTP    HTTPCheckOutput
 	Source                   string
+	AgentVersion             string
 }
 
 // runCidCheck finds providers of a given CID, using the DHT and IPNI
@@ -313,6 +341,12 @@ func (d *daemon) runCidCheck(ctx context.Context, cidKey cid.Cid, ipniURL string
 			if connErr != nil {
 				provOutput.ConnectionError = formatConnectionError(connErr, provider.Addrs)
 			} else {
+				// Retrieve AgentVersion from peerstore after successful connection
+				if agent, err := testHost.Peerstore().Get(provider.ID, "AgentVersion"); err == nil {
+					if agentStr, ok := agent.(string); ok {
+						provOutput.AgentVersion = sanitizeAgentVersion(agentStr)
+					}
+				}
 				// since we pass a libp2p host that's already connected to the peer the actual connection maddr we pass in doesn't matter
 				p2pAddr, _ := multiaddr.NewMultiaddr("/p2p/" + provider.ID.String())
 				provOutput.DataAvailableOverBitswap = checkBitswapCID(ctx, testHost, cidKey, p2pAddr)

--- a/daemon.go
+++ b/daemon.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -54,35 +53,9 @@ const (
 
 	ipniSource = "IPNI"
 	dhtSource  = "Amino DHT"
-
-	// maximum length for agent version string
-	maxAgentVersionLen = 64
 )
 
 var defaultProtocolFilter = []string{"transport-bitswap", "unknown"}
-
-// Regex to match only ASCII printable characters (space through tilde)
-// This ensures we only keep safe, printable ASCII chars
-var asciiPrintable = regexp.MustCompile(`[^\x20-\x7E]`)
-
-// sanitizeAgentVersion removes non-printable characters and limits length.
-// The Go json.Marshal will handle proper escaping of quotes, backslashes, etc.
-func sanitizeAgentVersion(version string) string {
-	// Replace non-ASCII and non-printable characters with underscore
-	// This removes control characters, non-ASCII, etc.
-	ascii := asciiPrintable.ReplaceAllString(version, "_")
-
-	// Trim whitespace
-	ascii = strings.TrimSpace(ascii)
-
-	// Limit to maximum length (count runes for proper UTF-8 handling)
-	runes := []rune(ascii)
-	if len(runes) > maxAgentVersionLen {
-		ascii = string(runes[:maxAgentVersionLen])
-	}
-
-	return ascii
-}
 
 func newDaemon(ctx context.Context, acceleratedDHT bool) (*daemon, error) {
 	rm, err := NewResourceManager()

--- a/version.go
+++ b/version.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"runtime/debug"
+	"strings"
 	"time"
+	"unicode"
 )
 
 //go:embed version.json
@@ -47,4 +49,47 @@ func buildVersion() string {
 		return fmt.Sprintf("%s %s-%s", release, day, revision)
 	}
 	return release + " dev-build"
+}
+
+const maxAgentVersionLen = 128
+
+// sanitizeAgentVersion sanitizes untrusted agent version strings from remote peers
+// to prevent display issues across web UIs, terminals, and logs. It replaces control
+// characters, format characters, and surrogate characters with U+FFFD (�), then enforces
+// a maximum length of 128 runes. Per RFC 9839, replacing problematic code points with
+// U+FFFD is preferred over silently deleting them, as deletion is a known security risk.
+// See https://github.com/libp2p/specs/pull/491 and https://www.rfc-editor.org/rfc/rfc9839.html for context.
+func sanitizeAgentVersion(version string) string {
+	// Build sanitized result
+	var result []rune
+	for _, r := range version {
+		// Replace control characters (Cc) with U+FFFD - prevents terminal escapes, CR, LF, etc.
+		if unicode.Is(unicode.Cc, r) {
+			result = append(result, '\uFFFD')
+			continue
+		}
+		// Replace format characters (Cf) with U+FFFD - prevents RTL/LTR overrides, zero-width chars
+		if unicode.Is(unicode.Cf, r) {
+			result = append(result, '\uFFFD')
+			continue
+		}
+		// Replace surrogate characters (Cs) with U+FFFD - invalid in UTF-8
+		if unicode.Is(unicode.Cs, r) {
+			result = append(result, '\uFFFD')
+			continue
+		}
+		// Preserve legitimate Unicode including private use characters (Co)
+		result = append(result, r)
+	}
+
+	// Convert to string and trim whitespace
+	sanitized := strings.TrimSpace(string(result))
+
+	// Enforce maximum length (128 runes, not bytes)
+	runes := []rune(sanitized)
+	if len(runes) > maxAgentVersionLen {
+		return string(runes[:maxAgentVersionLen])
+	}
+
+	return sanitized
 }

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeAgentVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "normal version string",
+			input:    "kubo/0.18.0",
+			expected: "kubo/0.18.0",
+		},
+		{
+			name:     "version with emoji preserved",
+			input:    "my-client/1.0.0 🚀",
+			expected: "my-client/1.0.0 🚀",
+		},
+		{
+			name:     "international characters preserved",
+			input:    "клиент/версия-1.0 测试",
+			expected: "клиент/версия-1.0 测试",
+		},
+		{
+			name:     "control characters replaced with U+FFFD",
+			input:    "client\x00\x01\x02/1.0",
+			expected: "client���/1.0",
+		},
+		{
+			name:     "newlines and tabs replaced",
+			input:    "client\n\r\t/1.0",
+			expected: "client���/1.0",
+		},
+		{
+			name:     "zero-width characters replaced",
+			input:    "client\u200B\u200C\u200D/1.0",
+			expected: "client���/1.0",
+		},
+		{
+			name:     "RTL/LTR overrides replaced",
+			input:    "client\u202A\u202B\u202C/1.0",
+			expected: "client���/1.0",
+		},
+		{
+			name:     "bidi isolates replaced",
+			input:    "client\u2066\u2067\u2068\u2069/1.0",
+			expected: "client����/1.0",
+		},
+		{
+			name:     "BOM replaced",
+			input:    "\uFEFFclient/1.0",
+			expected: "�client/1.0",
+		},
+		{
+			name:     "whitespace trimmed",
+			input:    "  client/1.0  ",
+			expected: "client/1.0",
+		},
+		{
+			name:     "whitespace trimmed after sanitization",
+			input:    "\x00  client/1.0  \x00",
+			expected: "�  client/1.0  �",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "only whitespace",
+			input:    "   ",
+			expected: "",
+		},
+		{
+			name:     "only control characters become replacement characters",
+			input:    "\x00\x01\x02",
+			expected: "���",
+		},
+		{
+			name:     "private use characters preserved",
+			input:    "client\uE000\uF8FF/1.0",
+			expected: "client\uE000\uF8FF/1.0",
+		},
+		{
+			name:     "length limited to 128 runes",
+			input:    strings.Repeat("a", 150),
+			expected: strings.Repeat("a", 128),
+		},
+		{
+			name:     "length limit preserves multibyte runes",
+			input:    strings.Repeat("世", 150),
+			expected: strings.Repeat("世", 128),
+		},
+		{
+			name:     "length limit after sanitization",
+			input:    "\x00" + strings.Repeat("a", 150),
+			expected: "�" + strings.Repeat("a", 127),
+		},
+		{
+			name:     "terminal escape sequences replaced",
+			input:    "client\x1b[31m/1.0\x1b[0m",
+			expected: "client�[31m/1.0�[0m",
+		},
+		{
+			name:     "mixed problematic and valid characters",
+			input:    "my\x00client\u200B/версия\u202A-1.0🚀",
+			expected: "my�client�/версия�-1.0🚀",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeAgentVersion(tt.input)
+			if result != tt.expected {
+				t.Errorf("sanitizeAgentVersion(%q) = %q, want %q", tt.input, result, tt.expected)
+				// Print runes for debugging
+				t.Logf("Result runes: %+q", result)
+				t.Logf("Expected runes: %+q", tt.expected)
+			}
+		})
+	}
+}
+
+func TestSanitizeAgentVersionMaxLength(t *testing.T) {
+	// Test that length is counted in runes, not bytes
+	// Each emoji is 1 rune but multiple bytes
+	emojis := strings.Repeat("🚀", 130)
+	result := sanitizeAgentVersion(emojis)
+	runeCount := len([]rune(result))
+	if runeCount != 128 {
+		t.Errorf("Expected 128 runes, got %d", runeCount)
+	}
+
+	// Test that multibyte characters are counted correctly
+	chinese := strings.Repeat("世", 130)
+	result = sanitizeAgentVersion(chinese)
+	runeCount = len([]rune(result))
+	if runeCount != 128 {
+		t.Errorf("Expected 128 runes, got %d", runeCount)
+	}
+}
+
+func TestSanitizeAgentVersionSecurity(t *testing.T) {
+	// Test that no control characters survive sanitization
+	dangerousInputs := []string{
+		"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f",
+		"\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f",
+		"\u200B\u200C\u200D\u202A\u202B\u202C\u202D\u202E",
+		"\u2066\u2067\u2068\u2069\uFEFF",
+	}
+
+	for _, input := range dangerousInputs {
+		result := sanitizeAgentVersion("test/" + input + "/1.0")
+		// Check that no control or format characters remain
+		for _, r := range result {
+			if r < 0x20 && r != '\uFFFD' {
+				t.Errorf("Control character %U found in sanitized output", r)
+			}
+			if r >= 0x200B && r <= 0x200D && r != '\uFFFD' {
+				t.Errorf("Zero-width character %U found in sanitized output", r)
+			}
+			if r >= 0x202A && r <= 0x202E && r != '\uFFFD' {
+				t.Errorf("Bidi override character %U found in sanitized output", r)
+			}
+			if r >= 0x2066 && r <= 0x2069 && r != '\uFFFD' {
+				t.Errorf("Bidi isolate character %U found in sanitized output", r)
+			}
+			if r == 0xFEFF && r != '\uFFFD' {
+				t.Errorf("BOM character %U found in sanitized output", r)
+			}
+		}
+	}
+}

--- a/web/script.js
+++ b/web/script.js
@@ -269,7 +269,13 @@ function formatJustCidOutput (resp) {
         outHtml += `</div>`
         if (hasBitswap) {
             outHtml += `<div class='flex items-center text-sm mb-1'>${couldConnect ? iconCheck : iconCross}<span>Libp2p connected: <span class='font-mono'>${couldConnect ? 'Yes' : provider.ConnectionError.replaceAll('\n', '<br>')}</span></span></div>`
-            outHtml += couldConnect ? `<div class='flex items-center text-sm mb-1 ml-6'>${provider.DataAvailableOverBitswap.Found ? iconCheck : iconCross}<span>Bitswap Check: <span class='font-mono'>${provider.DataAvailableOverBitswap.Found ? 'Found' : 'Not found'}</span> ${provider.DataAvailableOverBitswap.Error || ''}</span></div>` : ''
+            if (couldConnect) {
+                if (provider.AgentVersion) {
+                    outHtml += `<div class='flex items-center text-sm mb-1 ml-6'>${iconCheck}<span>Agent Version: <span class='font-mono'>${provider.AgentVersion}</span></span></div>`
+                }
+                const foundText = provider.DataAvailableOverBitswap.Found ? 'Found' : 'Not found'
+                outHtml += `<div class='flex items-center text-sm mb-1 ml-6'>${provider.DataAvailableOverBitswap.Found ? iconCheck : iconCross}<span>Bitswap Check: <span class='font-mono'>${foundText}</span> ${provider.DataAvailableOverBitswap.Error || ''}</span></div>`
+            }
         }
         if (hasHTTP) {
             const httpRes = provider.DataAvailableOverHTTP


### PR DESCRIPTION
Shows the AgentVersion from [libp2p identify protocol](https://github.com/libp2p/specs/blob/master/identify/README.md) below successful connections. The agent string is sanitized to ASCII-only and limited to 64 characters for clean terminal output.

The goal is to bring visibility into software versions that successfully host the data.

## Demo

> <img width="871" height="1076" alt="2025-09-12_08-30" src="https://github.com/user-attachments/assets/344c297b-6143-4f6d-9bae-c31b26a659a3" />
