### PR TITLE
fix: small race fixes

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -183,10 +183,14 @@ func (d *daemon) runCidCheck(ctx context.Context, cidKey cid.Cid, ipniURL string
 			}
 			source = ipniSource
 		}
+
+		// Protect providersCount with mutex to avoid race condition
+		mu.Lock()
 		providersCount++
 		if providersCount == maxProvidersCount {
 			done = true
 		}
+		mu.Unlock()
 
 		wg.Add(1)
 		go func(provider peer.AddrInfo, src string) {

--- a/daemon.go
+++ b/daemon.go
@@ -164,6 +164,10 @@ func (d *daemon) runCidCheck(ctx context.Context, cidKey cid.Cid, ipniURL string
 		var source string
 
 		select {
+		case <-ctx.Done():
+			// Respect the timeout from the URL/context
+			done = true
+			continue
 		case provider, open = <-dhtProvsCh:
 			if !open {
 				dhtProvsCh = nil


### PR DESCRIPTION
small nits:
- 8183f5b race condition: `providersCount` was accessed without synchronization, causing potential data races
- 4c970d5 missing timeout handling: Provider discovery loop didn't respect context timeout, could run indefinitely
