### PR TITLE
feat: add badge endpoint for IPFS availability badges

### DIFF
--- a/badge.go
+++ b/badge.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+const (
+	// Badge colors (shields.io style)
+	colorGreen  = "#4c1"    // Bright green - highly available (2+ providers)
+	colorYellow = "#dfb317" // Yellow - low availability (1 provider)
+	colorRed    = "#e05d44" // Red - unavailable (0 providers)
+	colorGray   = "#9f9f9f" // Gray - error/unknown state
+
+	// Badge dimensions
+	labelWidth  = 32 // Width for "IPFS" label
+	badgeHeight = 20
+)
+
+// generateBadgeSVG creates a shields.io-style SVG badge showing provider count and CID suffix.
+func generateBadgeSVG(providerCount int, cidSuffix string) []byte {
+	var color, status string
+
+	switch {
+	case providerCount == 0:
+		color = colorRed
+		status = fmt.Sprintf("unavailable ...%s", cidSuffix)
+	case providerCount == 1:
+		color = colorYellow
+		status = fmt.Sprintf("1 provider ...%s", cidSuffix)
+	default:
+		color = colorGreen
+		status = fmt.Sprintf("%d providers ...%s", providerCount, cidSuffix)
+	}
+
+	return buildBadgeSVG("IPFS", status, color)
+}
+
+// getCIDSuffix returns the last 6 characters of a CID string.
+func getCIDSuffix(cidStr string) string {
+	if len(cidStr) <= 6 {
+		return cidStr
+	}
+	return cidStr[len(cidStr)-6:]
+}
+
+// generateErrorBadgeSVG creates a badge indicating an error occurred.
+func generateErrorBadgeSVG(cidSuffix string) []byte {
+	return buildBadgeSVG("IPFS", fmt.Sprintf("error ...%s", cidSuffix), colorGray)
+}
+
+// generatePendingBadgeSVG creates a badge indicating the check is in progress.
+func generatePendingBadgeSVG(cidSuffix string) []byte {
+	return buildBadgeSVG("IPFS", fmt.Sprintf("checking ...%s", cidSuffix), colorGray)
+}
+
+// buildBadgeSVG constructs the SVG markup for a badge with given label, status, and color.
+func buildBadgeSVG(label, status, color string) []byte {
+	// Calculate widths based on text length (approximate)
+	statusWidth := len(status)*7 + 10
+	totalWidth := labelWidth + statusWidth
+	labelX := labelWidth / 2
+	statusX := labelWidth + statusWidth/2
+
+	svg := fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d">
+  <linearGradient id="b" x2="0" y2="100%%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="a">
+    <rect width="%d" height="%d" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#a)">
+    <rect width="%d" height="%d" fill="#555"/>
+    <rect x="%d" width="%d" height="%d" fill="%s"/>
+    <rect width="%d" height="%d" fill="url(#b)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="%d" y="15" fill="#010101" fill-opacity=".3">%s</text>
+    <text x="%d" y="14">%s</text>
+    <text x="%d" y="15" fill="#010101" fill-opacity=".3">%s</text>
+    <text x="%d" y="14">%s</text>
+  </g>
+</svg>`,
+		totalWidth, badgeHeight,
+		totalWidth, badgeHeight,
+		labelWidth, badgeHeight,
+		labelWidth, statusWidth, badgeHeight, color,
+		totalWidth, badgeHeight,
+		labelX, label,
+		labelX, label,
+		statusX, status,
+		statusX, status,
+	)
+
+	return []byte(svg)
+}
+
+// countWorkingProviders counts providers that are connected and have data available.
+func countWorkingProviders(providers *[]providerOutput) int {
+	if providers == nil {
+		return 0
+	}
+
+	count := 0
+	for _, p := range *providers {
+		if p.ConnectionError == "" &&
+			(p.DataAvailableOverBitswap.Found || p.DataAvailableOverHTTP.Found) {
+			count++
+		}
+	}
+	return count
+}
+
+// BadgeHandler handles HTTP requests for badge images.
+type BadgeHandler struct {
+	daemon       *daemon
+	cache        *BadgeCache
+	checkTimeout time.Duration
+}
+
+// NewBadgeHandler creates a new badge handler.
+func NewBadgeHandler(d *daemon, cache *BadgeCache, checkTimeout time.Duration) *BadgeHandler {
+	return &BadgeHandler{
+		daemon:       d,
+		cache:        cache,
+		checkTimeout: checkTimeout,
+	}
+}
+
+// ServeHTTP handles badge requests.
+// For uncached CIDs, it returns a "checking..." badge immediately and triggers
+// a background check. Subsequent requests will receive the cached result.
+func (h *BadgeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	cidStr := r.URL.Query().Get("cid")
+	if cidStr == "" {
+		http.Error(w, "missing 'cid' query parameter", http.StatusBadRequest)
+		return
+	}
+
+	cidSuffix := getCIDSuffix(cidStr)
+
+	// Try to get from cache first (includes completed results)
+	if entry, ok := h.cache.Get(cidStr); ok {
+		if !entry.Pending {
+			// Completed result - serve it
+			h.serveSVG(w, entry.SVG)
+			return
+		}
+		// Still pending - serve the pending badge
+		h.serveSVG(w, entry.SVG)
+		return
+	}
+
+	// Check if already pending (avoid duplicate background checks)
+	if h.cache.IsPending(cidStr) {
+		svg := generatePendingBadgeSVG(cidSuffix)
+		h.serveSVG(w, svg)
+		return
+	}
+
+	// Not in cache and not pending - start background check
+	pendingSVG := generatePendingBadgeSVG(cidSuffix)
+	h.cache.SetPending(cidStr, cidSuffix, pendingSVG)
+
+	// Trigger background check
+	go h.runBackgroundCheck(cidStr, cidSuffix)
+
+	// Return pending badge immediately
+	h.serveSVG(w, pendingSVG)
+}
+
+// runBackgroundCheck performs the CID check in the background and caches the result.
+func (h *BadgeHandler) runBackgroundCheck(cidStr, cidSuffix string) {
+	ctx, cancel := context.WithTimeout(context.Background(), h.checkTimeout)
+	defer cancel()
+
+	cidKey, _, err := resolveInput(ctx, h.daemon.ns, cidStr)
+	if err != nil {
+		log.Printf("Badge: failed to resolve CID %s: %v", cidStr, err)
+		svg := generateErrorBadgeSVG(cidSuffix)
+		h.cache.Set(cidStr, 0, cidSuffix, svg)
+		return
+	}
+
+	result, err := h.daemon.runCidCheck(ctx, cidKey, defaultIndexerURL, false)
+	if err != nil {
+		log.Printf("Badge: failed to check CID %s: %v", cidStr, err)
+		svg := generateErrorBadgeSVG(cidSuffix)
+		h.cache.Set(cidStr, 0, cidSuffix, svg)
+		return
+	}
+
+	// Count working providers and generate badge
+	providerCount := countWorkingProviders(result)
+	svg := generateBadgeSVG(providerCount, cidSuffix)
+
+	// Cache the result
+	h.cache.Set(cidStr, providerCount, cidSuffix, svg)
+	log.Printf("Badge: cached result for %s: %d providers", cidStr, providerCount)
+}
+
+// serveSVG writes an SVG response with appropriate headers.
+func (h *BadgeHandler) serveSVG(w http.ResponseWriter, svg []byte) {
+	w.Header().Set("Content-Type", "image/svg+xml")
+	w.Header().Set("Cache-Control", "public, max-age=3600") // Browser cache for 1 hour
+	w.Write(svg)
+}

--- a/badge_cache.go
+++ b/badge_cache.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"sync"
+	"time"
+)
+
+// BadgeCache provides a thread-safe in-memory cache for badge results.
+// This prevents repeated expensive CID checks for frequently requested badges.
+type BadgeCache struct {
+	mu    sync.RWMutex
+	items map[string]*BadgeCacheEntry
+	ttl   time.Duration
+}
+
+// BadgeCacheEntry holds cached badge data for a CID.
+type BadgeCacheEntry struct {
+	ProviderCount int
+	CIDSuffix     string
+	SVG           []byte
+	Timestamp     time.Time
+	Pending       bool // true if check is in progress
+}
+
+// NewBadgeCache creates a new badge cache with the specified TTL.
+func NewBadgeCache(ttl time.Duration) *BadgeCache {
+	cache := &BadgeCache{
+		items: make(map[string]*BadgeCacheEntry),
+		ttl:   ttl,
+	}
+	// Start background cleanup goroutine
+	go cache.cleanupLoop()
+	return cache
+}
+
+// Get retrieves a cached entry if it exists and hasn't expired.
+func (c *BadgeCache) Get(cid string) (*BadgeCacheEntry, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	entry, ok := c.items[cid]
+	if !ok {
+		return nil, false
+	}
+
+	if time.Since(entry.Timestamp) > c.ttl {
+		return nil, false
+	}
+
+	return entry, true
+}
+
+// Set stores a badge cache entry.
+func (c *BadgeCache) Set(cid string, providerCount int, cidSuffix string, svg []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.items[cid] = &BadgeCacheEntry{
+		ProviderCount: providerCount,
+		CIDSuffix:     cidSuffix,
+		SVG:           svg,
+		Timestamp:     time.Now(),
+		Pending:       false,
+	}
+}
+
+// SetPending marks a CID as having a check in progress.
+func (c *BadgeCache) SetPending(cid string, cidSuffix string, svg []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.items[cid] = &BadgeCacheEntry{
+		CIDSuffix: cidSuffix,
+		SVG:       svg,
+		Timestamp: time.Now(),
+		Pending:   true,
+	}
+}
+
+// IsPending checks if a CID has a pending check in progress.
+func (c *BadgeCache) IsPending(cid string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	entry, ok := c.items[cid]
+	if !ok {
+		return false
+	}
+	return entry.Pending
+}
+
+// cleanupLoop periodically removes expired entries from the cache.
+func (c *BadgeCache) cleanupLoop() {
+	ticker := time.NewTicker(c.ttl / 2)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		c.cleanup()
+	}
+}
+
+// cleanup removes all expired entries from the cache.
+func (c *BadgeCache) cleanup() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	for cid, entry := range c.items {
+		if now.Sub(entry.Timestamp) > c.ttl {
+			delete(c.items, cid)
+		}
+	}
+}
+
+// Size returns the current number of entries in the cache.
+func (c *BadgeCache) Size() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.items)
+}

--- a/badge_test.go
+++ b/badge_test.go
@@ -1,0 +1,380 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCIDSuffix(t *testing.T) {
+	t.Run("long CID returns last 6 characters", func(t *testing.T) {
+		cid := "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi"
+		result := getCIDSuffix(cid)
+		require.Equal(t, "5fbzdi", result)
+	})
+
+	t.Run("exactly 6 characters returns full string", func(t *testing.T) {
+		cid := "abcdef"
+		result := getCIDSuffix(cid)
+		require.Equal(t, "abcdef", result)
+	})
+
+	t.Run("less than 6 characters returns full string", func(t *testing.T) {
+		cid := "abc"
+		result := getCIDSuffix(cid)
+		require.Equal(t, "abc", result)
+	})
+
+	t.Run("empty string returns empty", func(t *testing.T) {
+		result := getCIDSuffix("")
+		require.Equal(t, "", result)
+	})
+}
+
+func TestGenerateBadgeSVG(t *testing.T) {
+	t.Run("0 providers shows red unavailable badge", func(t *testing.T) {
+		svg := generateBadgeSVG(0, "abc123")
+		svgStr := string(svg)
+
+		require.Contains(t, svgStr, "unavailable ...abc123")
+		require.Contains(t, svgStr, colorRed)
+		require.Contains(t, svgStr, "IPFS")
+	})
+
+	t.Run("1 provider shows yellow warning badge", func(t *testing.T) {
+		svg := generateBadgeSVG(1, "abc123")
+		svgStr := string(svg)
+
+		require.Contains(t, svgStr, "1 provider ...abc123")
+		require.Contains(t, svgStr, colorYellow)
+		require.Contains(t, svgStr, "IPFS")
+	})
+
+	t.Run("2 providers shows green badge", func(t *testing.T) {
+		svg := generateBadgeSVG(2, "abc123")
+		svgStr := string(svg)
+
+		require.Contains(t, svgStr, "2 providers ...abc123")
+		require.Contains(t, svgStr, colorGreen)
+		require.Contains(t, svgStr, "IPFS")
+	})
+
+	t.Run("10 providers shows green badge with plural", func(t *testing.T) {
+		svg := generateBadgeSVG(10, "xyz789")
+		svgStr := string(svg)
+
+		require.Contains(t, svgStr, "10 providers ...xyz789")
+		require.Contains(t, svgStr, colorGreen)
+	})
+
+	t.Run("SVG has valid structure", func(t *testing.T) {
+		svg := generateBadgeSVG(5, "test12")
+		svgStr := string(svg)
+
+		require.True(t, strings.HasPrefix(svgStr, "<svg"))
+		require.True(t, strings.HasSuffix(strings.TrimSpace(svgStr), "</svg>"))
+		require.Contains(t, svgStr, "xmlns=\"http://www.w3.org/2000/svg\"")
+	})
+}
+
+func TestGenerateErrorBadgeSVG(t *testing.T) {
+	t.Run("error badge has gray color and error text", func(t *testing.T) {
+		svg := generateErrorBadgeSVG("abc123")
+		svgStr := string(svg)
+
+		require.Contains(t, svgStr, "error ...abc123")
+		require.Contains(t, svgStr, colorGray)
+		require.Contains(t, svgStr, "IPFS")
+	})
+}
+
+func TestGeneratePendingBadgeSVG(t *testing.T) {
+	t.Run("pending badge has gray color and checking text", func(t *testing.T) {
+		svg := generatePendingBadgeSVG("abc123")
+		svgStr := string(svg)
+
+		require.Contains(t, svgStr, "checking ...abc123")
+		require.Contains(t, svgStr, colorGray)
+		require.Contains(t, svgStr, "IPFS")
+	})
+}
+
+func TestCountWorkingProviders(t *testing.T) {
+	t.Run("nil providers returns 0", func(t *testing.T) {
+		count := countWorkingProviders(nil)
+		require.Equal(t, 0, count)
+	})
+
+	t.Run("empty providers returns 0", func(t *testing.T) {
+		providers := []providerOutput{}
+		count := countWorkingProviders(&providers)
+		require.Equal(t, 0, count)
+	})
+
+	t.Run("provider with connection error not counted", func(t *testing.T) {
+		providers := []providerOutput{
+			{
+				ConnectionError:          "connection refused",
+				DataAvailableOverBitswap: BitswapCheckOutput{Found: true},
+			},
+		}
+		count := countWorkingProviders(&providers)
+		require.Equal(t, 0, count)
+	})
+
+	t.Run("provider with bitswap data counted", func(t *testing.T) {
+		providers := []providerOutput{
+			{
+				ConnectionError:          "",
+				DataAvailableOverBitswap: BitswapCheckOutput{Found: true},
+			},
+		}
+		count := countWorkingProviders(&providers)
+		require.Equal(t, 1, count)
+	})
+
+	t.Run("provider with HTTP data counted", func(t *testing.T) {
+		providers := []providerOutput{
+			{
+				ConnectionError:       "",
+				DataAvailableOverHTTP: HTTPCheckOutput{Found: true},
+			},
+		}
+		count := countWorkingProviders(&providers)
+		require.Equal(t, 1, count)
+	})
+
+	t.Run("provider with both bitswap and HTTP counted once", func(t *testing.T) {
+		providers := []providerOutput{
+			{
+				ConnectionError:          "",
+				DataAvailableOverBitswap: BitswapCheckOutput{Found: true},
+				DataAvailableOverHTTP:    HTTPCheckOutput{Found: true},
+			},
+		}
+		count := countWorkingProviders(&providers)
+		require.Equal(t, 1, count)
+	})
+
+	t.Run("multiple working providers counted correctly", func(t *testing.T) {
+		providers := []providerOutput{
+			{
+				ConnectionError:          "",
+				DataAvailableOverBitswap: BitswapCheckOutput{Found: true},
+			},
+			{
+				ConnectionError:       "",
+				DataAvailableOverHTTP: HTTPCheckOutput{Found: true},
+			},
+			{
+				ConnectionError:          "timeout",
+				DataAvailableOverBitswap: BitswapCheckOutput{Found: true},
+			},
+		}
+		count := countWorkingProviders(&providers)
+		require.Equal(t, 2, count)
+	})
+
+	t.Run("connected but no data not counted", func(t *testing.T) {
+		providers := []providerOutput{
+			{
+				ConnectionError:          "",
+				DataAvailableOverBitswap: BitswapCheckOutput{Found: false},
+				DataAvailableOverHTTP:    HTTPCheckOutput{Found: false},
+			},
+		}
+		count := countWorkingProviders(&providers)
+		require.Equal(t, 0, count)
+	})
+}
+
+func TestBadgeCache(t *testing.T) {
+	t.Run("Get returns false for non-existent key", func(t *testing.T) {
+		cache := NewBadgeCache(time.Hour)
+		_, ok := cache.Get("nonexistent")
+		require.False(t, ok)
+	})
+
+	t.Run("Set and Get work correctly", func(t *testing.T) {
+		cache := NewBadgeCache(time.Hour)
+		svg := []byte("<svg>test</svg>")
+
+		cache.Set("cid123", 5, "id123", svg)
+
+		entry, ok := cache.Get("cid123")
+		require.True(t, ok)
+		require.Equal(t, 5, entry.ProviderCount)
+		require.Equal(t, "id123", entry.CIDSuffix)
+		require.Equal(t, svg, entry.SVG)
+		require.False(t, entry.Pending)
+	})
+
+	t.Run("SetPending marks entry as pending", func(t *testing.T) {
+		cache := NewBadgeCache(time.Hour)
+		svg := []byte("<svg>pending</svg>")
+
+		cache.SetPending("cid123", "id123", svg)
+
+		entry, ok := cache.Get("cid123")
+		require.True(t, ok)
+		require.True(t, entry.Pending)
+	})
+
+	t.Run("IsPending returns correct state", func(t *testing.T) {
+		cache := NewBadgeCache(time.Hour)
+
+		require.False(t, cache.IsPending("nonexistent"))
+
+		cache.SetPending("cid123", "id123", []byte{})
+		require.True(t, cache.IsPending("cid123"))
+
+		cache.Set("cid123", 5, "id123", []byte{})
+		require.False(t, cache.IsPending("cid123"))
+	})
+
+	t.Run("expired entries are not returned", func(t *testing.T) {
+		cache := NewBadgeCache(10 * time.Millisecond)
+		cache.Set("cid123", 5, "id123", []byte{})
+
+		entry, ok := cache.Get("cid123")
+		require.True(t, ok)
+		require.Equal(t, 5, entry.ProviderCount)
+
+		time.Sleep(20 * time.Millisecond)
+
+		_, ok = cache.Get("cid123")
+		require.False(t, ok)
+	})
+
+	t.Run("Size returns correct count", func(t *testing.T) {
+		cache := NewBadgeCache(time.Hour)
+		require.Equal(t, 0, cache.Size())
+
+		cache.Set("cid1", 1, "id1", []byte{})
+		require.Equal(t, 1, cache.Size())
+
+		cache.Set("cid2", 2, "id2", []byte{})
+		require.Equal(t, 2, cache.Size())
+
+		cache.Set("cid1", 3, "id1", []byte{})
+		require.Equal(t, 2, cache.Size())
+	})
+
+	t.Run("cleanup removes expired entries", func(t *testing.T) {
+		cache := NewBadgeCache(10 * time.Millisecond)
+		cache.Set("cid1", 1, "id1", []byte{})
+		cache.Set("cid2", 2, "id2", []byte{})
+
+		require.Equal(t, 2, cache.Size())
+
+		time.Sleep(20 * time.Millisecond)
+		cache.cleanup()
+
+		require.Equal(t, 0, cache.Size())
+	})
+}
+
+func TestBadgeHandlerServeHTTP(t *testing.T) {
+	t.Run("missing cid parameter returns 400", func(t *testing.T) {
+		cache := NewBadgeCache(time.Hour)
+		handler := &BadgeHandler{
+			daemon:       nil,
+			cache:        cache,
+			checkTimeout: 30 * time.Second,
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/badge", nil)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "missing 'cid' query parameter")
+	})
+
+	t.Run("cached result is returned", func(t *testing.T) {
+		cache := NewBadgeCache(time.Hour)
+		svg := generateBadgeSVG(3, "abc123")
+		cache.Set("testcid123", 3, "abc123", svg)
+
+		handler := &BadgeHandler{
+			daemon:       nil,
+			cache:        cache,
+			checkTimeout: 30 * time.Second,
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/badge?cid=testcid123", nil)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "image/svg+xml", w.Header().Get("Content-Type"))
+		require.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+		require.Contains(t, w.Header().Get("Cache-Control"), "max-age=3600")
+		require.Contains(t, w.Body.String(), "3 providers ...abc123")
+	})
+
+	t.Run("pending result returns pending badge", func(t *testing.T) {
+		cache := NewBadgeCache(time.Hour)
+		pendingSVG := generatePendingBadgeSVG("xyz789")
+		cache.SetPending("pendingcid", "xyz789", pendingSVG)
+
+		handler := &BadgeHandler{
+			daemon:       nil,
+			cache:        cache,
+			checkTimeout: 30 * time.Second,
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/badge?cid=pendingcid", nil)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Contains(t, w.Body.String(), "checking ...xyz789")
+	})
+
+	t.Run("CORS header is set", func(t *testing.T) {
+		cache := NewBadgeCache(time.Hour)
+		cache.Set("testcid", 1, "testci", []byte("<svg></svg>"))
+
+		handler := &BadgeHandler{
+			daemon:       nil,
+			cache:        cache,
+			checkTimeout: 30 * time.Second,
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/badge?cid=testcid", nil)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+	})
+}
+
+func TestBuildBadgeSVG(t *testing.T) {
+	t.Run("builds valid SVG with correct dimensions", func(t *testing.T) {
+		svg := buildBadgeSVG("TEST", "status text", "#ff0000")
+		svgStr := string(svg)
+
+		require.Contains(t, svgStr, "xmlns=\"http://www.w3.org/2000/svg\"")
+		require.Contains(t, svgStr, "TEST")
+		require.Contains(t, svgStr, "status text")
+		require.Contains(t, svgStr, "#ff0000")
+		require.Contains(t, svgStr, "height=\"20\"")
+	})
+
+	t.Run("label and status are both rendered twice for shadow effect", func(t *testing.T) {
+		svg := buildBadgeSVG("LABEL", "STATUS", "#00ff00")
+		svgStr := string(svg)
+
+		require.Equal(t, 2, strings.Count(svgStr, ">LABEL<"))
+		require.Equal(t, 2, strings.Count(svgStr, ">STATUS<"))
+	})
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -163,7 +163,7 @@ func TestBasicIntegration(t *testing.T) {
 			},
 			httpSkipVerify: true,
 		}
-		_ = startServer(ctx, d, ":1234", "", "")
+		_ = startServer(ctx, d, ":1234", "", "", nil)
 	}()
 
 	h, err := libp2p.New()

--- a/main.go
+++ b/main.go
@@ -67,6 +67,24 @@ func main() {
 			EnvVars: []string{"IPFS_CHECK_METRICS_AUTH_PASS"},
 			Usage:   "http basic auth password for the metrics endpoints",
 		},
+		&cli.BoolFlag{
+			Name:    "enable-badges",
+			Value:   false,
+			EnvVars: []string{"IPFS_CHECK_ENABLE_BADGES"},
+			Usage:   "enable the badge endpoint for generating IPFS availability badges",
+		},
+		&cli.DurationFlag{
+			Name:    "badge-cache-ttl",
+			Value:   24 * time.Hour,
+			EnvVars: []string{"IPFS_CHECK_BADGE_CACHE_TTL"},
+			Usage:   "how long to cache badge results",
+		},
+		&cli.DurationFlag{
+			Name:    "badge-check-timeout",
+			Value:   30 * time.Second,
+			EnvVars: []string{"IPFS_CHECK_BADGE_TIMEOUT"},
+			Usage:   "timeout for badge CID checks",
+		},
 	}
 	app.Action = func(cctx *cli.Context) error {
 		ctx := cctx.Context
@@ -76,7 +94,13 @@ func main() {
 			return err
 		}
 
-		return startServer(ctx, d, cctx.String("address"), cctx.String("metrics-auth-username"), cctx.String("metrics-auth-password"))
+		badgeConfig := &BadgeConfig{
+			Enabled:      cctx.Bool("enable-badges"),
+			CacheTTL:     cctx.Duration("badge-cache-ttl"),
+			CheckTimeout: cctx.Duration("badge-check-timeout"),
+		}
+
+		return startServer(ctx, d, cctx.String("address"), cctx.String("metrics-auth-username"), cctx.String("metrics-auth-password"), badgeConfig)
 	}
 
 	err := app.Run(os.Args)
@@ -91,7 +115,14 @@ const (
 	libp2pKeyCodec      = 0x72 // multicodec for libp2p-key (PeerID in CIDv1 format)
 )
 
-func startServer(ctx context.Context, d *daemon, tcpListener, metricsUsername, metricPassword string) error {
+// BadgeConfig holds configuration for the badge endpoint.
+type BadgeConfig struct {
+	Enabled      bool
+	CacheTTL     time.Duration
+	CheckTimeout time.Duration
+}
+
+func startServer(ctx context.Context, d *daemon, tcpListener, metricsUsername, metricPassword string, badgeConfig *BadgeConfig) error {
 	log.Printf("Starting %s %s\n", name, version)
 	l, err := net.Listen("tcp", tcpListener)
 	if err != nil {
@@ -246,6 +277,14 @@ func startServer(ctx context.Context, d *daemon, tcpListener, metricsUsername, m
 
 	// Use a single metrics endpoint for all Prometheus metrics
 	http.Handle("/metrics", BasicAuth(promhttp.HandlerFor(d.promRegistry, promhttp.HandlerOpts{}), metricsUsername, metricPassword))
+
+	// Badge endpoint (opt-in)
+	if badgeConfig != nil && badgeConfig.Enabled {
+		badgeCache := NewBadgeCache(badgeConfig.CacheTTL)
+		badgeHandler := NewBadgeHandler(d, badgeCache, badgeConfig.CheckTimeout)
+		http.Handle("/badge", badgeHandler)
+		log.Printf("Badge endpoint enabled at http://%s/badge", webAddr)
+	}
 
 	// Serve frontend on /web
 	fileServer := http.FileServer(http.FS(webFS))


### PR DESCRIPTION
## Summary

- Add opt-in `/badge` endpoint that generates shields.io-style SVG badges showing real-time IPFS provider availability
- Color-coded badges: green (2+ providers), yellow (1 provider), red (0 providers), gray (error/pending)
- Shows provider count and last 6 characters of CID (e.g., "2 providers ...5fbzdi")
- Non-blocking background checks with "checking..." badge returned immediately
- In-memory cache with configurable TTL (default 24 hours)
- Configurable via `--enable-badges` flag and `IPFS_CHECK_ENABLE_BADGES` environment variable

## Test plan

- [x] Unit tests added for all badge functions (32 test cases)
- [x] Manual testing verified badge states: checking → cached result
- [x] Verified color coding: green/yellow/red/gray
- [x] Verified HTTP headers: Content-Type, CORS, Cache-Control
- [x] All existing tests pass

Closes #118