### PR TITLE
fix: keep enriching provider records past stale ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
-- UI hint when every returned provider record lacks a current multiaddr, pointing at likely stale records and the option to switch routing endpoint in Backend Config. The hint is rendered from the existing response shape; no wire format changes.
+- ✨ A CID with provider records that all arrive without addresses no longer dead-ends as "0 working providers". The UI now surfaces a hint explaining that the records are likely stale and points at the Backend Config to try a different routing endpoint. The hint reads existing fields from the response, so the JSON wire format is unchanged.
 
 ### Changed
 
@@ -24,7 +24,8 @@ The following emojis are used to highlight certain changes:
 - [go-libp2p-kad-dht v0.39.1](https://github.com/libp2p/go-libp2p-kad-dht/releases/tag/v0.39.1) (from v0.38.0)
 - bumped GitHub Actions to latest majors: `actions/checkout@v6`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`, `actions/upload-pages-artifact@v5`, `actions/deploy-pages@v5`, `docker/setup-qemu-action@v4`, `docker/setup-buildx-action@v4`, `docker/login-action@v4`, `docker/build-push-action@v7`
 - README rewritten for clarity: active voice, scannable headings, and simpler phrasing
-- CID-only provider lookup now mirrors Kubo's `ipfs routing findprovs --num-providers` default of 20 instead of stopping after 10 raw records. Records without any usable multiaddr no longer consume a result slot; the backend keeps draining DHT and IPNI until it has up to 20 providers with at least one address, capped at 40 attempts. `FindPeer` enrichment for address-less records runs in parallel across providers on the full request context (no artificially short per-call budget), so stale records have the best chance of being resolved within the user-supplied timeout.
+- ✨ CID-only checks now keep looking for usable providers instead of stopping after the first 10 records the routing layer returned. The backend drains DHT and IPNI streams until it has up to 20 providers that resolved at least one multiaddr, capped at 40 attempted records overall. Records without addresses no longer occupy a result slot, and `FindPeer` enrichment for those records runs in parallel for the full request timeout. The target of 20 is sized so a single check approximates the providers Kubo's bitswap would accumulate over the lifetime of a real retrieval.
+- ✨ Per-provider bitswap dials are now seeded with addresses the daemon's main host already learned for the target peer, on top of the record's own addresses and the `FindPeer` fallback. The bitswap dial timeout moves from 15s to 30s so NAT hole-punches and relay setup have time to complete. The user-visible effect: providers the previous code rejected as "failed to dial: no addresses" can now succeed when the daemon has a recent address for the peer from earlier lookups.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
+- UI hint when every returned provider record lacks a current multiaddr, pointing at likely stale records and the option to switch routing endpoint in Backend Config. The hint is rendered from the existing response shape; no wire format changes.
+
 ### Changed
 
 - [boxo v0.39.0](https://github.com/ipfs/boxo/releases/tag/v0.39.0) (from v0.37.0)
@@ -22,6 +24,7 @@ The following emojis are used to highlight certain changes:
 - [go-libp2p-kad-dht v0.39.1](https://github.com/libp2p/go-libp2p-kad-dht/releases/tag/v0.39.1) (from v0.38.0)
 - bumped GitHub Actions to latest majors: `actions/checkout@v6`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`, `actions/upload-pages-artifact@v5`, `actions/deploy-pages@v5`, `docker/setup-qemu-action@v4`, `docker/setup-buildx-action@v4`, `docker/login-action@v4`, `docker/build-push-action@v7`
 - README rewritten for clarity: active voice, scannable headings, and simpler phrasing
+- CID-only provider lookup now mirrors Kubo's `ipfs routing findprovs --num-providers` default of 20 instead of stopping after 10 raw records. Records without any usable multiaddr no longer consume a result slot; the backend keeps draining DHT and IPNI until it has up to 20 providers with at least one address, capped at 40 attempts. `FindPeer` enrichment for address-less records runs in parallel across providers on the full request context (no artificially short per-call budget), so stale records have the best chance of being resolved within the user-supplied timeout.
 
 ### Removed
 

--- a/daemon.go
+++ b/daemon.go
@@ -47,9 +47,21 @@ type daemon struct {
 }
 
 const (
-	// number of providers at which to stop looking for providers in the DHT
-	// When doing a check only with a CID
-	maxProvidersCount = 10
+	// maxProvidersCount is the soft cap: once we have this many providers that
+	// resolved to at least one usable multiaddr (either inline in the provider
+	// record or via a FindPeer fallback), we stop dispatching new work.
+	// Provider records without any addresses do not count toward this cap, so
+	// stale records cannot starve the result set.
+	//
+	// 20 mirrors Kubo's `ipfs routing findprovs --num-providers` default.
+	maxProvidersCount = 20
+
+	// maxAttemptedProviders is the hard cap on how many provider records we
+	// will process per request. Bounds the worst-case fan-out when most
+	// records are stale (no addresses) and FindPeer enrichment also fails.
+	// 2x the soft cap leaves headroom for stale records without exploding the
+	// number of concurrent libp2p hosts the daemon has to spawn per request.
+	maxAttemptedProviders = 2 * maxProvidersCount
 
 	ipniSource = "IPNI"
 	dhtSource  = "Amino DHT"
@@ -177,21 +189,23 @@ func (d *daemon) runCidCheck(ctx context.Context, cidKey cid.Cid, ipniURL string
 	queryCtx, cancelQuery := context.WithCancel(ctx)
 	defer cancelQuery()
 
-	// half of the max providers count per source
-	providersPerSource := maxProvidersCount >> 1
-	if maxProvidersCount == 1 {
-		// Ensure at least one provider from each source when maxProvidersCount is 1
-		providersPerSource = 1
-	}
+	// Stream providers from both sources without an artificial cap (count=0).
+	// We control termination here based on results, not on a raw arrival count,
+	// so that stale provider records without addresses do not exhaust the
+	// budget before useful ones arrive.
+	dhtProvsCh := d.dht.FindProvidersAsync(queryCtx, cidKey, 0)
+	ipniProvsCh := routerClient.FindProvidersAsync(queryCtx, cidKey, 0)
 
-	// Find providers with DHT and IPNI concurrently (each half of the max providers count)
-	dhtProvsCh := d.dht.FindProvidersAsync(queryCtx, cidKey, providersPerSource)
-	ipniProvsCh := routerClient.FindProvidersAsync(queryCtx, cidKey, providersPerSource)
-
-	out := make([]providerOutput, 0, maxProvidersCount)
+	out := make([]providerOutput, 0, maxAttemptedProviders)
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	var providersCount int
+	// dispatchedCount counts goroutines spawned (hard cap).
+	// withAddrsCount counts goroutines that resolved at least one usable
+	// address, either from the provider record or via the FindPeer fallback
+	// (soft cap). Only the soft cap is what users care about; without it, a
+	// burst of address-less stale records would cancel the lookup before any
+	// usable provider arrived.
+	var dispatchedCount, withAddrsCount int
 	var done bool
 
 	for !done {
@@ -224,125 +238,29 @@ func (d *daemon) runCidCheck(ctx context.Context, cidKey cid.Cid, ipniURL string
 			source = ipniSource
 		}
 
-		// Protect providersCount with mutex to avoid race condition
 		mu.Lock()
-		providersCount++
-		if providersCount == maxProvidersCount {
+		if withAddrsCount >= maxProvidersCount || dispatchedCount >= maxAttemptedProviders {
 			done = true
+			mu.Unlock()
+			continue
 		}
+		dispatchedCount++
 		mu.Unlock()
 
 		wg.Add(1)
 		go func(provider peer.AddrInfo, src string) {
 			defer wg.Done()
 
-			provOutput := providerOutput{
-				ID:                       provider.ID.String(),
-				Source:                   src,
-				DataAvailableOverBitswap: BitswapCheckOutput{},
-				DataAvailableOverHTTP:    HTTPCheckOutput{},
-			}
-
-			testHost, err := d.createTestHost()
-			if err != nil {
-				log.Printf("Error creating test host: %v\n", err)
+			provOutput, ok := d.checkProvider(ctx, cidKey, provider, src, httpRetrieval)
+			if !ok {
 				return
-			}
-			defer testHost.Close()
-
-			// Get http retrieval out of the way if this is such
-			// provider.
-			httpInfo, libp2pInfo := network.SplitHTTPAddrs(provider)
-			if len(httpInfo.Addrs) > 0 && httpRetrieval {
-				provOutput.DataAvailableOverHTTP.Enabled = true
-
-				for _, ma := range httpInfo.Addrs {
-					provOutput.Addrs = append(provOutput.Addrs, ma.String())
-				}
-
-				testHost, err := d.createTestHost()
-				if err != nil {
-					log.Printf("Error creating test host: %v\n", err)
-					return
-				}
-				defer testHost.Close()
-				httpCheck := checkHTTPRetrieval(ctx, testHost, cidKey, httpInfo, d.httpSkipVerify)
-				provOutput.DataAvailableOverHTTP = httpCheck
-				if !httpCheck.Connected {
-					provOutput.ConnectionError = httpCheck.Error
-				}
-				for _, ma := range httpCheck.Endpoints {
-					provOutput.ConnectionMaddrs = append(provOutput.ConnectionMaddrs, ma.String())
-				}
-
-				// Do not continue processing if there are no
-				// other addresses as we would trigger dht
-				// lookups etc.
-				if len(libp2pInfo.Addrs) == 0 {
-					provOutput.DataAvailableOverBitswap.Enabled = false
-					mu.Lock()
-					out = append(out, provOutput)
-					mu.Unlock()
-
-					return
-				}
-			}
-
-			// process non-http providers addresses.
-			provider = libp2pInfo
-
-			outputAddrs := []string{}
-			if len(provider.Addrs) > 0 {
-				for _, addr := range provider.Addrs {
-					if manet.IsPublicAddr(addr) { // only return public addrs
-						outputAddrs = append(outputAddrs, addr.String())
-					}
-				}
-			} else {
-				// If no maddrs were returned from the FindProvider rpc call, try to get them from the DHT
-				peerAddrs, err := d.dht.FindPeer(ctx, provider.ID)
-				if err == nil {
-					for _, addr := range peerAddrs.Addrs {
-						if manet.IsPublicAddr(addr) { // only return public addrs
-							// Add to both output and to provider addrs for the check
-							outputAddrs = append(outputAddrs, addr.String())
-							provider.Addrs = append(provider.Addrs, addr)
-						}
-					}
-				}
-			}
-
-			provOutput.Addrs = append(provOutput.Addrs, outputAddrs...)
-			provOutput.DataAvailableOverBitswap.Enabled = true
-
-			// Test Is the target connectable
-			dialCtx, dialCancel := context.WithTimeout(ctx, time.Second*15)
-			defer dialCancel()
-
-			_ = testHost.Connect(dialCtx, provider)
-			// Call NewStream to force NAT hole punching. see https://github.com/libp2p/go-libp2p/issues/2714
-			_, connErr := testHost.NewStream(dialCtx, provider.ID, "/ipfs/bitswap/1.2.0", "/ipfs/bitswap/1.1.0", "/ipfs/bitswap/1.0.0", "/ipfs/bitswap")
-
-			if connErr != nil {
-				provOutput.ConnectionError = formatConnectionError(connErr, provider.Addrs)
-			} else {
-				// Retrieve AgentVersion from peerstore after successful connection
-				if agent, err := testHost.Peerstore().Get(provider.ID, "AgentVersion"); err == nil {
-					if agentStr, ok := agent.(string); ok {
-						provOutput.AgentVersion = sanitizeAgentVersion(agentStr)
-					}
-				}
-				// since we pass a libp2p host that's already connected to the peer the actual connection maddr we pass in doesn't matter
-				p2pAddr, _ := multiaddr.NewMultiaddr("/p2p/" + provider.ID.String())
-				provOutput.DataAvailableOverBitswap = checkBitswapCID(ctx, testHost, cidKey, p2pAddr)
-
-				for _, c := range testHost.Network().ConnsToPeer(provider.ID) {
-					provOutput.ConnectionMaddrs = append(provOutput.ConnectionMaddrs, c.RemoteMultiaddr().String())
-				}
 			}
 
 			mu.Lock()
 			out = append(out, provOutput)
+			if len(provOutput.Addrs) > 0 {
+				withAddrsCount++
+			}
 			mu.Unlock()
 		}(provider, source)
 	}
@@ -352,6 +270,113 @@ func (d *daemon) runCidCheck(ctx context.Context, cidKey cid.Cid, ipniURL string
 	wg.Wait()
 
 	return &out, nil
+}
+
+// checkProvider resolves addresses for a single provider record (falling back
+// to a DHT FindPeer on the full request context when the record carries no
+// usable addresses) and then probes the provider over HTTP and/or Bitswap.
+//
+// FindPeer fallback runs in parallel across providers because each
+// checkProvider is invoked from its own goroutine in runCidCheck.
+//
+// The second return value is false when an internal failure (currently:
+// inability to construct a libp2p host) prevents producing any meaningful
+// result; the caller should drop the provider rather than append a stub.
+func (d *daemon) checkProvider(ctx context.Context, cidKey cid.Cid, provider peer.AddrInfo, src string, httpRetrieval bool) (providerOutput, bool) {
+	provOutput := providerOutput{
+		ID:                       provider.ID.String(),
+		Source:                   src,
+		DataAvailableOverBitswap: BitswapCheckOutput{},
+		DataAvailableOverHTTP:    HTTPCheckOutput{},
+	}
+
+	testHost, err := d.createTestHost()
+	if err != nil {
+		log.Printf("Error creating test host: %v\n", err)
+		return provOutput, false
+	}
+	defer testHost.Close()
+
+	httpInfo, libp2pInfo := network.SplitHTTPAddrs(provider)
+	if len(httpInfo.Addrs) > 0 && httpRetrieval {
+		provOutput.DataAvailableOverHTTP.Enabled = true
+
+		for _, ma := range httpInfo.Addrs {
+			provOutput.Addrs = append(provOutput.Addrs, ma.String())
+		}
+
+		httpHost, err := d.createTestHost()
+		if err != nil {
+			log.Printf("Error creating test host: %v\n", err)
+			return provOutput, false
+		}
+		defer httpHost.Close()
+		httpCheck := checkHTTPRetrieval(ctx, httpHost, cidKey, httpInfo, d.httpSkipVerify)
+		provOutput.DataAvailableOverHTTP = httpCheck
+		if !httpCheck.Connected {
+			provOutput.ConnectionError = httpCheck.Error
+		}
+		for _, ma := range httpCheck.Endpoints {
+			provOutput.ConnectionMaddrs = append(provOutput.ConnectionMaddrs, ma.String())
+		}
+
+		if len(libp2pInfo.Addrs) == 0 {
+			provOutput.DataAvailableOverBitswap.Enabled = false
+			return provOutput, true
+		}
+	}
+
+	provider = libp2pInfo
+
+	outputAddrs := []string{}
+	if len(provider.Addrs) > 0 {
+		for _, addr := range provider.Addrs {
+			if manet.IsPublicAddr(addr) {
+				outputAddrs = append(outputAddrs, addr.String())
+			}
+		}
+	} else {
+		// Provider record had no addresses. Try the DHT for a fresh peer
+		// record on the full request context, so we keep enriching for as
+		// long as the user-supplied timeout allows.
+		peerAddrs, err := d.dht.FindPeer(ctx, provider.ID)
+		if err == nil {
+			for _, addr := range peerAddrs.Addrs {
+				if manet.IsPublicAddr(addr) {
+					outputAddrs = append(outputAddrs, addr.String())
+					provider.Addrs = append(provider.Addrs, addr)
+				}
+			}
+		}
+	}
+
+	provOutput.Addrs = append(provOutput.Addrs, outputAddrs...)
+	provOutput.DataAvailableOverBitswap.Enabled = true
+
+	dialCtx, dialCancel := context.WithTimeout(ctx, time.Second*15)
+	defer dialCancel()
+
+	_ = testHost.Connect(dialCtx, provider)
+	// Call NewStream to force NAT hole punching. see https://github.com/libp2p/go-libp2p/issues/2714
+	_, connErr := testHost.NewStream(dialCtx, provider.ID, "/ipfs/bitswap/1.2.0", "/ipfs/bitswap/1.1.0", "/ipfs/bitswap/1.0.0", "/ipfs/bitswap")
+
+	if connErr != nil {
+		provOutput.ConnectionError = formatConnectionError(connErr, provider.Addrs)
+		return provOutput, true
+	}
+	if agent, err := testHost.Peerstore().Get(provider.ID, "AgentVersion"); err == nil {
+		if agentStr, ok := agent.(string); ok {
+			provOutput.AgentVersion = sanitizeAgentVersion(agentStr)
+		}
+	}
+	p2pAddr, _ := multiaddr.NewMultiaddr("/p2p/" + provider.ID.String())
+	provOutput.DataAvailableOverBitswap = checkBitswapCID(ctx, testHost, cidKey, p2pAddr)
+
+	for _, c := range testHost.Network().ConnsToPeer(provider.ID) {
+		provOutput.ConnectionMaddrs = append(provOutput.ConnectionMaddrs, c.RemoteMultiaddr().String())
+	}
+
+	return provOutput, true
 }
 
 type peerCheckOutput struct {

--- a/daemon.go
+++ b/daemon.go
@@ -186,8 +186,8 @@ func (d *daemon) runCidCheck(ctx context.Context, cidKey cid.Cid, ipniURL string
 
 	// count=0 streams unbounded; we cap termination on results below so
 	// address-less records do not exhaust the budget.
-	dhtProvsCh := d.dht.FindProvidersAsync(queryCtx, cidKey, 0)
-	ipniProvsCh := routerClient.FindProvidersAsync(queryCtx, cidKey, 0)
+	dhtProvsCh := d.dht.FindProvidersAsync(queryCtx, cidKey, maxAttemptedProviders)
+	ipniProvsCh := routerClient.FindProvidersAsync(queryCtx, cidKey, maxAttemptedProviders)
 
 	out := make([]providerOutput, 0, maxAttemptedProviders)
 	var wg sync.WaitGroup

--- a/daemon.go
+++ b/daemon.go
@@ -47,20 +47,15 @@ type daemon struct {
 }
 
 const (
-	// maxProvidersCount is the soft cap: once we have this many providers that
-	// resolved to at least one usable multiaddr (either inline in the provider
-	// record or via a FindPeer fallback), we stop dispatching new work.
-	// Provider records without any addresses do not count toward this cap, so
-	// stale records cannot starve the result set.
-	//
-	// 20 mirrors Kubo's `ipfs routing findprovs --num-providers` default.
+	// Soft cap on providers with at least one usable multiaddr. Stale
+	// (address-less) records do not consume a slot. Sized larger than the
+	// 10 that Kubo's bitswap requests per provider-search round, because
+	// ipfs-check probes once and cannot repeat the round as a long-lived
+	// bitswap session would.
 	maxProvidersCount = 20
 
-	// maxAttemptedProviders is the hard cap on how many provider records we
-	// will process per request. Bounds the worst-case fan-out when most
-	// records are stale (no addresses) and FindPeer enrichment also fails.
-	// 2x the soft cap leaves headroom for stale records without exploding the
-	// number of concurrent libp2p hosts the daemon has to spawn per request.
+	// Hard cap on processed records per request. Bounds fan-out when every
+	// record is stale.
 	maxAttemptedProviders = 2 * maxProvidersCount
 
 	ipniSource = "IPNI"
@@ -189,22 +184,17 @@ func (d *daemon) runCidCheck(ctx context.Context, cidKey cid.Cid, ipniURL string
 	queryCtx, cancelQuery := context.WithCancel(ctx)
 	defer cancelQuery()
 
-	// Stream providers from both sources without an artificial cap (count=0).
-	// We control termination here based on results, not on a raw arrival count,
-	// so that stale provider records without addresses do not exhaust the
-	// budget before useful ones arrive.
+	// count=0 streams unbounded; we cap termination on results below so
+	// address-less records do not exhaust the budget.
 	dhtProvsCh := d.dht.FindProvidersAsync(queryCtx, cidKey, 0)
 	ipniProvsCh := routerClient.FindProvidersAsync(queryCtx, cidKey, 0)
 
 	out := make([]providerOutput, 0, maxAttemptedProviders)
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-	// dispatchedCount counts goroutines spawned (hard cap).
-	// withAddrsCount counts goroutines that resolved at least one usable
-	// address, either from the provider record or via the FindPeer fallback
-	// (soft cap). Only the soft cap is what users care about; without it, a
-	// burst of address-less stale records would cancel the lookup before any
-	// usable provider arrived.
+	// withAddrsCount feeds the soft cap; dispatchedCount feeds the hard cap.
+	// Counting only address-resolved providers against the soft cap prevents
+	// stale-record bursts from cancelling the lookup early.
 	var dispatchedCount, withAddrsCount int
 	var done bool
 
@@ -272,16 +262,17 @@ func (d *daemon) runCidCheck(ctx context.Context, cidKey cid.Cid, ipniURL string
 	return &out, nil
 }
 
-// checkProvider resolves addresses for a single provider record (falling back
-// to a DHT FindPeer on the full request context when the record carries no
-// usable addresses) and then probes the provider over HTTP and/or Bitswap.
+// checkProvider probes a single provider over HTTP and/or Bitswap.
 //
-// FindPeer fallback runs in parallel across providers because each
-// checkProvider is invoked from its own goroutine in runCidCheck.
+// Each probe builds its own libp2p host. Sharing one host across the
+// request's goroutines is unsafe because vole.CheckBitswapCID installs a
+// bitswap stream handler via host.SetStreamHandler, which replaces any
+// prior handler; concurrent probes would then deliver responses to the
+// wrong receiver. httpnet has the same shape of issue with connection
+// notifiers, so the HTTP path also uses its own host.
 //
-// The second return value is false when an internal failure (currently:
-// inability to construct a libp2p host) prevents producing any meaningful
-// result; the caller should drop the provider rather than append a stub.
+// Returns false when a probe host cannot be constructed; the caller
+// should drop the provider rather than append a stub.
 func (d *daemon) checkProvider(ctx context.Context, cidKey cid.Cid, provider peer.AddrInfo, src string, httpRetrieval bool) (providerOutput, bool) {
 	provOutput := providerOutput{
 		ID:                       provider.ID.String(),
@@ -289,13 +280,6 @@ func (d *daemon) checkProvider(ctx context.Context, cidKey cid.Cid, provider pee
 		DataAvailableOverBitswap: BitswapCheckOutput{},
 		DataAvailableOverHTTP:    HTTPCheckOutput{},
 	}
-
-	testHost, err := d.createTestHost()
-	if err != nil {
-		log.Printf("Error creating test host: %v\n", err)
-		return provOutput, false
-	}
-	defer testHost.Close()
 
 	httpInfo, libp2pInfo := network.SplitHTTPAddrs(provider)
 	if len(httpInfo.Addrs) > 0 && httpRetrieval {
@@ -329,31 +313,56 @@ func (d *daemon) checkProvider(ctx context.Context, cidKey cid.Cid, provider pee
 	provider = libp2pInfo
 
 	outputAddrs := []string{}
-	if len(provider.Addrs) > 0 {
-		for _, addr := range provider.Addrs {
-			if manet.IsPublicAddr(addr) {
-				outputAddrs = append(outputAddrs, addr.String())
-			}
+	seen := map[string]struct{}{}
+	addPublicAddr := func(addr multiaddr.Multiaddr, alsoDial bool) {
+		if !manet.IsPublicAddr(addr) {
+			return
 		}
-	} else {
-		// Provider record had no addresses. Try the DHT for a fresh peer
-		// record on the full request context, so we keep enriching for as
-		// long as the user-supplied timeout allows.
+		s := addr.String()
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		outputAddrs = append(outputAddrs, s)
+		if alsoDial {
+			provider.Addrs = append(provider.Addrs, addr)
+		}
+	}
+
+	// Record addresses: only the public ones surface in the output. Private
+	// entries remain in provider.Addrs for libp2p, which the gater rejects.
+	for _, addr := range provider.Addrs {
+		addPublicAddr(addr, false)
+	}
+
+	// FindPeer when the record had no public addrs. Full ctx: the user's
+	// timeout bounds the wait.
+	if len(outputAddrs) == 0 {
 		peerAddrs, err := d.dht.FindPeer(ctx, provider.ID)
 		if err == nil {
 			for _, addr := range peerAddrs.Addrs {
-				if manet.IsPublicAddr(addr) {
-					outputAddrs = append(outputAddrs, addr.String())
-					provider.Addrs = append(provider.Addrs, addr)
-				}
+				addPublicAddr(addr, true)
 			}
 		}
+	}
+
+	// Merge addrs the daemon's peerstore already holds from prior DHT
+	// lookups, identifies, and earlier probes. Mirrors Kubo's dialing.
+	for _, addr := range d.h.Peerstore().Addrs(provider.ID) {
+		addPublicAddr(addr, true)
 	}
 
 	provOutput.Addrs = append(provOutput.Addrs, outputAddrs...)
 	provOutput.DataAvailableOverBitswap.Enabled = true
 
-	dialCtx, dialCancel := context.WithTimeout(ctx, time.Second*15)
+	testHost, err := d.createTestHost()
+	if err != nil {
+		log.Printf("Error creating test host: %v\n", err)
+		return provOutput, false
+	}
+	defer testHost.Close()
+
+	dialCtx, dialCancel := context.WithTimeout(ctx, time.Second*30)
 	defer dialCancel()
 
 	_ = testHost.Connect(dialCtx, provider)

--- a/web/script.js
+++ b/web/script.js
@@ -410,7 +410,7 @@ function formatJustCidOutput (resp) {
     // hint. This typically means the closest DHT peers held stale provider
     // records and the FindPeer fallback could not find the peer either, so
     // the network has nothing fresh to dial.
-    const allNoAddrs = providers.every(p => !p.Addrs || p.Addrs.length === 0)
+    const allNoAddrs = providers.length > 0 && providers.every(p => !p.Addrs || p.Addrs.length === 0)
     if (allNoAddrs) {
         outHtml += `<div class='bg-yellow-100 border-l-4 border-yellow-500 text-yellow-800 p-4 rounded mb-4 flex gap-x-2 items-start'>${iconInfo}<span>None of the returned provider records contained a current multiaddr. The records are likely stale (providers re-advertised the CID long ago and have since gone offline or changed addresses), or the routing layer did not have fresh peer information. Try again later, ask the publisher to re-provide, or test against a different routing endpoint in <b>Backend Config</b>.</span></div>`
     }

--- a/web/script.js
+++ b/web/script.js
@@ -405,6 +405,16 @@ function formatJustCidOutput (resp) {
     })
 
     outHtml += `<div class='mb-4'><span class='text-lg font-bold'>${successfulProviders > 0 ? iconCheck : iconCross} Found ${successfulProviders} working providers</span> <span class='text-gray-600'>(out of ${providers.length} provider records sampled from Amino DHT and IPNI) that could be connected to and had the CID available over Bitswap:</span></div>`
+
+    // If every returned provider record lacked any usable address, surface a
+    // hint. This typically means the closest DHT peers held stale provider
+    // records and the FindPeer fallback could not find the peer either, so
+    // the network has nothing fresh to dial.
+    const allNoAddrs = providers.every(p => !p.Addrs || p.Addrs.length === 0)
+    if (allNoAddrs) {
+        outHtml += `<div class='bg-yellow-100 border-l-4 border-yellow-500 text-yellow-800 p-4 rounded mb-4 flex gap-x-2 items-start'>${iconInfo}<span>None of the returned provider records contained a current multiaddr. The records are likely stale (providers re-advertised the CID long ago and have since gone offline or changed addresses), or the routing layer did not have fresh peer information. Try again later, ask the publisher to re-provide, or test against a different routing endpoint in <b>Backend Config</b>.</span></div>`
+    }
+
     outHtml += `<div class='grid gap-4 grid-cols-1'>`
     for (const provider of providers) {
         const couldConnect = provider.ConnectionError === ''


### PR DESCRIPTION

This PR brings ipfs-check closer to how real world Kubo provider lookup looks like during retrieval. cc @aschmahmann as he noticed https://check.ipfs.network/ being flaky with `/ipns/ipfs.tech` (which has high drive-by provider churn).

## Problem

Provider records returned by the DHT often arrive without addresses. For CIDs with high provider churn like `/ipns/ipfs.tech`, the previous 10-record cap was exhausted by stale records before any usable provider arrived. Even when the routing layer did return one, each per-provider probe ran on a fresh libp2p host with an empty peerstore, so addresses the daemon had already learned for that peer were ignored.

## Solution

Keep the same record-arrival behavior, but stop counting address-less records against the soft cap, drain longer, let `FindPeer` enrichment run on the full request context, and seed each bitswap dial with addresses the daemon already knows for the peer.

### Details

**Commit 90bd607 (soft/hard caps + UI hint)**

- `daemon.go`: split the per-provider worker into `checkProvider`; stream with `count=0` from both DHT and IPNI; soft cap of 20 counts only providers that resolved at least one usable multiaddr; hard cap of 40 bounds total attempts. 20 is sized for how many providers Kubo's bitswap accumulates across a real retrieval (10 per provider-search round, several rounds per session).
- `web/script.js`: when every returned record lacks a multiaddr, show a hint that records are likely stale and point at Backend Config.
- `CHANGELOG.md`: documents the UI hint and the soft/hard cap behavior.

**Commit 7f8dab3 (peerstore-seeded dials, longer timeout)**

- `checkProvider` seeds each bitswap dial with addresses the daemon's main host already holds for the target peer, on top of record-supplied addrs and any `FindPeer` fallback. Mirrors how Kubo's bitswap dials.
- The probe host stays per-provider. Sharing one host across the request's concurrent probes is unsafe because `vole.CheckBitswapCID` installs a bitswap stream handler via `host.SetStreamHandler`, which replaces any prior handler, so a shared host would route every probe's responses to whichever receiver was registered last and the others' messages would fail the sender-vs-target check inside `bsReceiver`.
- Bitswap dial timeout raised from 15s to 30s so more NAT hole-punches and relay setups have time to complete, simulating real-world Kubo behavior.
- `web/script.js`: the "records likely stale" hint now requires at least one returned record, so it does not fire when the routing layer returned nothing at all.

### Difference

| Before | After (This PR)  |
| ---- | ---- |
| <img width="1703" height="2533" alt="image" src="https://github.com/user-attachments/assets/679a02ad-68d8-4a55-85d6-f9ca7beae977" /> | <img width="1703" height="10990" alt="image" src="https://github.com/user-attachments/assets/8b912237-6ceb-435a-8f12-5a83d279f56f" /> |

Smoke test on a cold local ipfs-check backend daemon for `/ipns/ipfs.tech` (accelerated DHT off):

|  | Before (main) | After (this PR) |
| ---- | ---- | ---- |
| Attempted records | 5 | 40 |
| With at least one address | 0 | 12 |
| `Bitswap.Found=true` | 0 | 2 |

Production with the accelerated DHT warmed up should do better.

### Should we revisit other places?

Namely, does Kubo fail on `/ipns/ipfs.tech`? I think No.
I ran two fresh Kubo nodes and got identical results:

| Config | `findprovs` | `ipfs ls /ipns/ipfs.tech` |
| ---- | ---- | ---- |
| Default (`Routing.Type=auto`, autoconf on) | 20 providers | success in 2.3s |
| DHT-only (`Routing.Type=dht`, no delegated) | 20 providers | success in 4.7s |

Both Kubo runs effectively retrieve over the DHT for this CID. `cid.contact` returns 404. The DHT-only run had no delegated routers at all and still succeeded. The retrieval gap is therefore specific to ipfs-check, not the routing layer. It came from the cold per-probe host and the early cap on records, both of which this PR fixes.


